### PR TITLE
A few changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The blending textures are generated with `warp_blending_mask.py` and [OpenCV](ht
 
 ### Using the calibration utility
 
+![Calibration screen](http://i.imgur.com/EuivEcq.jpg)
+
 Prerequisites:
 
 * You'll need a copy of Visual Studio to compile the code
@@ -42,10 +44,18 @@ Once you've done this...
 * The code currently assumes 6 projectors: 3 columns across and 2 rows
 * Your displays need to be connected in the correct order so that the Nvidia utilities number them 1-6, reading from top left to bottom right.
 * Set up Mosaic using the Nvidia Control Panel to put the displays in the right basic configuration, and enable it.  Windows should now consider it has one big display attached.
-* If you have any existing warping applied, make sure you run *UnwarpAll-Quadros* to clear it before calibrating.
+* Make sure there is *zero* overlap specified in Mosaic.
+* If you have any existing warping applied,  run *UnwapAll-Quadros* to clear it before calibrating.
 * Open the `calibrate_screens.html` page in Chrome, or in any other browser that will let you display it full-screen and give you access to the console log.
-* Six coloured quadrilaterals will appear, each should be positions basically on one projector, and your aim is to move their corner points so that the corners on adjacent quadrilaterals are aligned.  The controls for doing this are described below.
-* When you have aligned everything, the necessary coordinates will be output to the browser console log.  Copy these into a text file named `coords_for_warp.txt` and run the *WarpBlend-Quadros* utility, and it will use these to set up the warping and blending.
+* Six coloured quadrilaterals will appear, each should be positioned basically on one projector, and your aim is to move their corner points so that the corners on adjacent quadrilaterals are aligned.  The controls for doing this are described below.
+
+![Calibration screen closeup](http://i.imgur.com/PQ2FLry.jpg)
+
+* When you have aligned everything, the necessary coordinates will be output to the browser console log.  Copy these into a text file named `coords_for_warp.txt`.
+* Look at the overlap values specified at the top of the coordinate file (default 30 horizontal, 90 vertical). Put these into the Mosaic configuration.
+* Copy the coordinates into `warp_blending_mask.py` and run it to generate the blend mask PNGs `blend_*.png`.
+*  Run the *WarpBlend-Quadros* utility, and it will use the coordinates to set up the warping and the mask PNGs to do the blending.  The coordinate file and the mask PNGs need to be *in the current working directory* when you run the utility.
+
 
 Controls for the calibration screen:
 
@@ -53,7 +63,7 @@ Controls for the calibration screen:
 *  Ctrl-click to move it to approximately the right location.  You want to position each corner roughly in the middle of the overlapping zone of the projectors.
 *  Use cursor keys to make fine adjustments to the selected corner, and then move on to the next corner.
 *  You can use the Q, W, E, A, S, & D keys to toggle on or off the rectangle displayed at each corresponding location.
-*  You can use the shift key with the cursor keys to change the size of the overlap area.
-*  Finally, press 'P', and the coordinates will be printed to the browser's console log; you can copy them into a text file.
+*  You can use the shift key with the cursor keys to change the size of the overlap area if needed.
+*  Finally, press 'P', and the coordinates will be printed to the browser's console log; you can copy and paste them from here.
 
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,33 @@ The blending textures are generated with `warp_blending_mask.py` and [OpenCV](ht
 *Nvidia Mosaic* is a utility that allows the operating system to view multiple displays as a single unified desktop environment without degrading performance or needing to modify third-party software. It also allows users to specify projector overlap regions so the desktop display transitions seamlessly over the entire display without discontinuities.
 
 *NVAPI Quadro Warp/Blend* lets us warp displays with a warping mesh to remove keystone distortion. In our case, each projected display has a quadrilateral warping mesh. These transformations are done in the display pipeline before pixels are scanned out, and leverage GPU hardware to perform fast high-quality image filtering operations. It also allows a blending texture to be loaded and applied to each display which modifies the output intensity of each pixel.
+
+
+### Using the calibration utility
+
+Prerequisites:
+
+* You'll need a copy of Visual Studio to compile the code
+* You need to download a copy of [the NVidia NVAPI library](https://developer.nvidia.com/nvapi).
+* Using these to compile the two utilities, *WarpBlend-Quadros* and *UnwarpAll-Quadros*, is left as an exercise for the reader!
+
+Once you've done this...
+
+* The code currently assumes 6 projectors: 3 columns across and 2 rows
+* Your displays need to be connected in the correct order so that the Nvidia utilities number them 1-6, reading from top left to bottom right.
+* Set up Mosaic using the Nvidia Control Panel to put the displays in the right basic configuration, and enable it.  Windows should now consider it has one big display attached.
+* If you have any existing warping applied, make sure you run *UnwarpAll-Quadros* to clear it before calibrating.
+* Open the `calibrate_screens.html` page in Chrome, or in any other browser that will let you display it full-screen and give you access to the console log.
+* Six coloured quadrilaterals will appear, each should be positions basically on one projector, and your aim is to move their corner points so that the corners on adjacent quadrilaterals are aligned.  The controls for doing this are described below.
+* When you have aligned everything, the necessary coordinates will be output to the browser console log.  Copy these into a text file named `coords_for_warp.txt` and run the *WarpBlend-Quadros* utility, and it will use these to set up the warping and blending.
+
+Controls for the calibration screen:
+
+*  Click in one of the rectangles to select the nearest corner of that rectangle.  The corner will turn white.
+*  Ctrl-click to move it to approximately the right location.  You want to position each corner roughly in the middle of the overlapping zone of the projectors.
+*  Use cursor keys to make fine adjustments to the selected corner, and then move on to the next corner.
+*  You can use the Q, W, E, A, S, & D keys to toggle on or off the rectangle displayed at each corresponding location.
+*  You can use the shift key with the cursor keys to change the size of the overlap area.
+*  Finally, press 'P', and the coordinates will be printed to the browser's console log; you can copy them into a text file.
+
+

--- a/WarpBlend-Quadros/WarpBlend-Quadros/getCoords.cpp
+++ b/WarpBlend-Quadros/WarpBlend-Quadros/getCoords.cpp
@@ -2,8 +2,10 @@
 
 // for reading a file into a string
 #include <string>
+#include <iostream>
 #include <fstream>
 #include <streambuf>
+#include <windows.h>
 
 #include <regex>
 
@@ -16,19 +18,26 @@ vector<float> get_warping_vertices(int row, int col, float srcLeft, float srcTop
 
 	// read coordinates file into str
 	std::ifstream f("coords_for_warp.txt");
+	if (!f.is_open()) {
+		std::cout << "Failed to open coords file\n";
+		throw "Failed to open coords file";
+	}
 	std::string str((std::istreambuf_iterator<char>(f)),
 					 std::istreambuf_iterator<char>());
 
+	printf("Using warping:\n----------------\n%s\n----------------\n", str.c_str());
 	// extract float coordinates from text using regex
 	std::regex regex(
 		"ROW: " + to_string(row) + " COL: " + to_string(col) + "\\n"
 		"\\(\\s*(\\-?[0-9]+.[0-9]+),\\s*(\\-?[0-9]+.[0-9]+)\\)\\s+"		// top left corner (x,y)
-		"\\(\\s*(\\-?[0-9]+.[0-9]+),\\s*(\\-?[0-9]+.[0-9]+)\\)\\s\\n"	// top right corner (x,y)
+		"\\(\\s*(\\-?[0-9]+.[0-9]+),\\s*(\\-?[0-9]+.[0-9]+)\\)\\s*\\n"	// top right corner (x,y)
 		"\\(\\s*(\\-?[0-9]+.[0-9]+),\\s*(\\-?[0-9]+.[0-9]+)\\)\\s+"		// bottom left corner (x,y)
 		"\\(\\s*(\\-?[0-9]+.[0-9]+),\\s*(\\-?[0-9]+.[0-9]+)\\)"			// bottom right corner (x,y)
 		);
 	std::smatch match;
 	std::regex_search(str, match, regex);
+
+	std::cout << "coords found:" << match.size() << std::endl;
 
 	// extract coordinates of quadrilateral corners
 	Vector2f tl = Vector2f(stof(match[1].str()), stof(match[2].str()));

--- a/utils/calibrate_screens.html
+++ b/utils/calibrate_screens.html
@@ -72,7 +72,7 @@ function redraw_paths() {
                         + (s_r == 0 ? (cps[3].position-cps[1].position).normalize()*overlap_v/2 : 0),
         cps[2].position - (s_c != 0 ? (cps[3].position-cps[2].position).normalize()*overlap_h/2 : 0)
                         + (s_r == 0 ? (cps[2].position-cps[0].position).normalize()*overlap_v/2 : 0)];
-      
+
       cps.align_path = new Path(align_segs);
       cps.blend_path = new Path(blend_segs);
 
@@ -89,19 +89,35 @@ function onMouseDown(evt) {
 
   // choose which set of cps to adjust based on mouse position
   var pt = evt.point;
-  var cps = ctrl_pts[pt.y<vh/2 ? 0 : 1][pt.x<2*vw/3 ? pt.x<vw/3 ? 0 : 1 : 2]
 
-  var cp_to_move = cps[0];
-  for (cp_idx=0; cp_idx<=3; cp_idx++){
-    dist = (cps[cp_idx].position - evt.point).length
-    if (dist < (cp_to_move.position - evt.point).length)
-      cp_to_move = cps[cp_idx];
+  // Clicking in a rectangle selects the nearest corner
+
+  if (! Key.isDown('control')) {
+
+
+    var cps = ctrl_pts[pt.y<vh/2 ? 0 : 1][pt.x<2*vw/3 ? pt.x<vw/3 ? 0 : 1 : 2]
+
+    var cp_to_move = cps[0];
+    for (cp_idx=0; cp_idx<=3; cp_idx++){
+      dist = (cps[cp_idx].position - evt.point).length
+      if (dist < (cp_to_move.position - evt.point).length)
+        cp_to_move = cps[cp_idx];
+    }
+
+
+    if (selected_ctrl_pt)
+        selected_ctrl_pt.fillColor = "transparent";
+    selected_ctrl_pt = cp_to_move;
+    if (selected_ctrl_pt)
+      selected_ctrl_pt.fillColor = "white";
+
+  } else {
+
+    // Ctrl-clicking moves the currently-selected point
+
+    selected_ctrl_pt.position = pt;
+
   }
-
-  selected_ctrl_pt = cp_to_move;
-
-  cp_to_move.position = pt;
-
   redraw_paths();
 }
 
@@ -109,7 +125,7 @@ function onKeyDown(event) {
 
   if (Key.isDown("shift")) {
 
-    // Adjust overlap sizes
+    // Adjust overlap sizes with shift+cursor keys
     if (event.key == 'up')    overlap_v++;
     if (event.key == 'down')  overlap_v--;
     if (event.key == 'left')  overlap_h--;
@@ -125,6 +141,7 @@ function onKeyDown(event) {
 
   }
 
+  // Toggle a rectangle using Q,W,E, A,S,D
   if ("qweasd".indexOf(event.key) != -1) {
     var s_row = "asd".indexOf(event.key) != -1 ? 1 : 0,
         s_col = "qwe".indexOf(event.key) * "asd".indexOf(event.key) * -1;
@@ -138,7 +155,7 @@ function onKeyDown(event) {
     } else ctrl_pt.blanking_rect.opacity = 1 - ctrl_pt.blanking_rect.opacity;
   }
 
-  // Print coordinates for warp
+  // Press 'P' to print coordinates for warp to browser console
   if(event.key == 'p') {
 
   	var output = "";


### PR DESCRIPTION
Hi Erroll - 

Some suggested updates from me, Ian and Gyorgy:

* I've put some more detailed instructions in the README

* I made the regex for parsing the coordinates slightly more forgiving: it used to require a space at the end of one of the lines, which was easy to lose by accident if cutting/pasting or if you opened it in an editor that trimmed trailing whitespace.

* We now require you to press Ctrl to actually _move_ one of the calibration points.  A simple click highlights the nearest one, and a ctrl-click moves it.  That stops accidental clicks from spoiling your careful alignment!

* A couple of extra error and debugging messages to reduce the situations when things can fail silently.

Let us know if we've made any mistakes!
All the best, 
Q
